### PR TITLE
chore(git): add minimal .gitignore (ignore .vscode exept shared tasks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,29 @@
+<<<<<<< Updated upstream
 preview/
+=======
+# ----- editor/OS noise -----
+.vscode/*
+!.vscode/tasks.json
+!.vscode/extensions.json
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# ----- project previews / scratch -----
+preview/
+
+# ----- Python cache (for helper scripts) -----
+__pycache__/
+*.pyc
+
+# ----- LaTeX aux files (harmless if unused) -----
+*.aux
+*.log
+*.out
+*.toc
+*.fls
+*.fdb_latexmk
+*.synctex.gz
+
+# Intentionally DO NOT ignore PDFs (they are part of the repo)
+>>>>>>> Stashed changes


### PR DESCRIPTION
## TL;DR
Unify `.gitignore` so local editor noise doesn’t block branch switches; keep PDFs tracked.

## Context / Problem
Switching branches on Windows repeatedly failed to delete the untracked `.vscode/` folder. We want a stable, shared ignore policy and to preserve one-click VS Code tasks if we add them later.

## Changes
- Add minimal `.gitignore`:
  - Ignore `.vscode/*`, but allow `tasks.json` and `extensions.json`
  - Ignore OS/editor junk (`.DS_Store`, `Thumbs.db`, `desktop.ini`)
  - Ignore Python caches (`__pycache__/`, `*.pyc`)
  - Include LaTeX aux patterns (harmless if unused)
  - **Intentionally do not ignore PDFs** (they’re part of the repo)

## Rationale
- Prevents “Deletion of directory '.vscode' failed” prompts on branch switches
- Keeps the door open for shared VS Code tasks without tracking all editor settings
- Keeps recruiter-facing PDFs versioned and visible

## Test Plan
- On `dev` and `main`, verify:
  ```bash
  git status        # no noisy untracked editor/OS files
  git switch main   # no .vscode deletion prompts
  git switch dev    # idem