### PR TITLE
fix(git): remove conflict markers; finalize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,11 @@
-<<<<<<< Updated upstream
-preview/
-=======
-# ----- editor/OS noise -----
 .vscode/*
 !.vscode/tasks.json
-!.vscode/extensions.json
 .DS_Store
 Thumbs.db
 desktop.ini
-
-# ----- project previews / scratch -----
 preview/
-
-# ----- Python cache (for helper scripts) -----
 __pycache__/
 *.pyc
-
-# ----- LaTeX aux files (harmless if unused) -----
 *.aux
 *.log
 *.out
@@ -24,6 +13,3 @@ __pycache__/
 *.fls
 *.fdb_latexmk
 *.synctex.gz
-
-# Intentionally DO NOT ignore PDFs (they are part of the repo)
->>>>>>> Stashed changes


### PR DESCRIPTION
## TL;DR
Remove leftover conflict markers and finalize `.gitignore` so editor/OS noise doesn’t block branch switches.

## Context / Problem
`.gitignore` contained conflict markers from an earlier stash/merge. VS Code kept showing the conflict UI and branch switches on Windows were noisy.

## Changes
- Clean `.gitignore`:
  - Ignore `.vscode/*`, but allow `tasks.json` (and `extensions.json` later if we add it)
  - Ignore OS/editor files: `.DS_Store`, `Thumbs.db`, `desktop.ini`
  - Ignore Python caches: `__pycache__/`, `*.pyc`
  - Include LaTeX aux patterns
  - Keep PDFs **tracked**

## Test Plan
- `git status` is clean on both branches.
- `grep -nE '<<<<<<<|=======|>>>>>>>' .gitignore` → no output.
- Switching branches no longer prompts to delete `.vscode`.

## Risk / Backout
- **Low**. Single file; revert PR to undo.
