### PR TITLE
chore(repo): add .gitattributes + PR template (normalize line endings; standardize PRs)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Default: keep LF in repo (good for HTML/JS/MD/shell)
+* text=auto eol=lf
+
+# Windows scripts should have CRLF in working tree
+*.bat text eol=crlf
+*.ps1 text eol=crlf
+
+# Shell / code files (explicit LF for clarity)
+*.sh   text eol=lf
+*.md   text eol=lf
+*.html text eol=lf
+*.css  text eol=lf
+*.js   text eol=lf
+*.json text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+*.py   text eol=lf
+
+# Binary assets: never change line endings / no diffs
+*.pdf   binary
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.ttf   binary
+*.otf   binary
+*.woff  binary
+*.woff2 binary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## TL;DR
+…
+
+## Context / Problem
+…
+
+## Changes
+…
+
+## Test Plan
+…
+
+## Risk / Backout
+Low | Medium | High — how to revert?
+
+## Checklist
+- [ ] Target branch correct
+- [ ] Only intended files changed
+- [ ] CI/lint green
+- [ ] No secrets/PII


### PR DESCRIPTION
## TL;DR
Repo hygiene: normalize line endings with `.gitattributes` and add a reusable PR template.

## Context / Problem
- Line-ending warnings and cross-OS diffs were noisy.
- PRs varied in structure; we want a consistent, skimmable format.

## Changes
- Add `.gitattributes`:
  - Default LF in repo; CRLF for `.bat`/`.ps1`.
  - Mark common binaries (`*.pdf`, images, fonts) as `binary`.
- Add `.github/pull_request_template.md`:
  - TL;DR, Context, Changes, Test Plan, Risk/Backout, Checklist.

## Test Plan
- Line endings:
  - `git ls-files --eol | findstr /R "\.bat \|\.ps1 \|\.sh \|\.html \|\.pdf"` (Windows)
  - Confirm bat/ps1 show `crlf`, others `lf`, and binaries `-text`.
- Template:
  - Open a test PR and confirm the description auto-populates.

## Risk / Backout
- **Low.** Config/docs only. Revert this PR to undo.

## Checklist
- [x] Target branch correct (`dev → main`)
- [x] Only expected files changed (`.gitattributes`, PR template)
- [x] CI/lint (if any) green
- [x] No secrets/PII
